### PR TITLE
Implement variable_bounds as Dict

### DIFF
--- a/src/callbacks_stage/bounds_check.jl
+++ b/src/callbacks_stage/bounds_check.jl
@@ -145,34 +145,30 @@ end
     println("─"^100)
     println("Maximum deviation from bounds:")
     println("─"^100)
-    counter = 1
     if local_minmax
-        for index in limiter.local_minmax_variables_cons
-            println("$(variables[index]):")
-            println("-lower bound: ", idp_bounds_delta[counter])
-            println("-upper bound: ", idp_bounds_delta[counter + 1])
-            counter += 2
+        for v in limiter.local_minmax_variables_cons
+            println("$(variables[v]):")
+            println("-lower bound: ", idp_bounds_delta[Symbol("$(v)_min")])
+            println("-upper bound: ", idp_bounds_delta[Symbol("$(v)_max")])
         end
     end
     if spec_entropy
-        println("spec. entropy:\n- lower bound: ", idp_bounds_delta[counter])
-        counter += 1
+        println("spec. entropy:\n- lower bound: ", idp_bounds_delta[:spec_entropy_min])
     end
     if math_entropy
-        println("math. entropy:\n- upper bound: ", idp_bounds_delta[counter])
-        counter += 1
+        println("math. entropy:\n- upper bound: ", idp_bounds_delta[:math_entropy_max])
     end
     if positivity
-        for index in limiter.positivity_variables_cons
-            if index in limiter.local_minmax_variables_cons
+        for v in limiter.positivity_variables_cons
+            if v in limiter.local_minmax_variables_cons
                 continue
             end
-            println("$(variables[index]):\n- positivity: ", idp_bounds_delta[counter])
-            counter += 1
+            println("$(variables[v]):\n- positivity: ",
+                    idp_bounds_delta[Symbol("$(v)_min")])
         end
         for variable in limiter.positivity_variables_nonlinear
-            println("$(variable):\n- positivity: ", idp_bounds_delta[counter])
-            counter += 1
+            println("$(variable):\n- positivity: ",
+                    idp_bounds_delta[Symbol("$(variable)_min")])
         end
     end
     println("─"^100 * "\n")

--- a/src/solvers/dgsem_tree/containers_2d.jl
+++ b/src/solvers/dgsem_tree/containers_2d.jl
@@ -1325,16 +1325,16 @@ mutable struct ContainerSubcellLimiterIDP2D{uEltype <: Real}
     alpha::Array{uEltype, 3}                  # [i, j, element]
     alpha1::Array{uEltype, 3}
     alpha2::Array{uEltype, 3}
-    variable_bounds::Vector{Array{uEltype, 3}}
+    variable_bounds::Dict{Symbol, Array{uEltype, 3}}
     # internal `resize!`able storage
     _alpha::Vector{uEltype}
     _alpha1::Vector{uEltype}
     _alpha2::Vector{uEltype}
-    _variable_bounds::Vector{Vector{uEltype}}
+    _variable_bounds::Dict{Symbol, Vector{uEltype}}
 end
 
 function ContainerSubcellLimiterIDP2D{uEltype}(capacity::Integer, n_nodes,
-                                               length) where {uEltype <: Real}
+                                               bound_keys) where {uEltype <: Real}
     nan_uEltype = convert(uEltype, NaN)
 
     # Initialize fields with defaults
@@ -1345,12 +1345,12 @@ function ContainerSubcellLimiterIDP2D{uEltype}(capacity::Integer, n_nodes,
     _alpha2 = fill(nan_uEltype, n_nodes * (n_nodes + 1) * capacity)
     alpha2 = unsafe_wrap(Array, pointer(_alpha2), (n_nodes, n_nodes + 1, capacity))
 
-    _variable_bounds = Vector{Vector{uEltype}}(undef, length)
-    variable_bounds = Vector{Array{uEltype, 3}}(undef, length)
-    for i in 1:length
-        _variable_bounds[i] = fill(nan_uEltype, n_nodes * n_nodes * capacity)
-        variable_bounds[i] = unsafe_wrap(Array, pointer(_variable_bounds[i]),
-                                         (n_nodes, n_nodes, capacity))
+    _variable_bounds = Dict{Symbol, Vector{uEltype}}()
+    variable_bounds = Dict{Symbol, Array{uEltype, 3}}()
+    for key in bound_keys
+        _variable_bounds[key] = fill(nan_uEltype, n_nodes * n_nodes * capacity)
+        variable_bounds[key] = unsafe_wrap(Array, pointer(_variable_bounds[key]),
+                                           (n_nodes, n_nodes, capacity))
     end
 
     return ContainerSubcellLimiterIDP2D{uEltype}(alpha, alpha1, alpha2,
@@ -1380,10 +1380,11 @@ function Base.resize!(container::ContainerSubcellLimiterIDP2D, capacity)
                                    (n_nodes, n_nodes + 1, capacity))
 
     @unpack _variable_bounds = container
-    for i in 1:length(_variable_bounds)
-        resize!(_variable_bounds[i], n_nodes * n_nodes * capacity)
-        container.variable_bounds[i] = unsafe_wrap(Array, pointer(_variable_bounds[i]),
-                                                   (n_nodes, n_nodes, capacity))
+    for (key, _) in _variable_bounds
+        resize!(_variable_bounds[key], n_nodes * n_nodes * capacity)
+        container.variable_bounds[key] = unsafe_wrap(Array,
+                                                     pointer(_variable_bounds[key]),
+                                                     (n_nodes, n_nodes, capacity))
     end
 
     return nothing

--- a/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
+++ b/src/solvers/dgsem_tree/dg_2d_subcell_limiters.jl
@@ -534,12 +534,11 @@ end
     @unpack variable_bounds = limiter.cache.subcell_limiter_coefficients
     @unpack bar_states1, bar_states2 = limiter.cache.container_bar_states
 
-    counter = 1
     # state variables
     if limiter.local_minmax
         for index in limiter.local_minmax_variables_cons
-            var_min = variable_bounds[counter]
-            var_max = variable_bounds[counter + 1]
+            var_min = variable_bounds[Symbol("$(index)_min")]
+            var_max = variable_bounds[Symbol("$(index)_max")]
             @threaded for element in eachelement(dg, cache)
                 var_min[:, :, element] .= typemax(eltype(var_min))
                 var_max[:, :, element] .= typemin(eltype(var_max))
@@ -571,12 +570,11 @@ end
                                                  bar_states2[index, i, j + 1, element])
                 end
             end
-            counter += 2
         end
     end
     # Specific Entropy
     if limiter.spec_entropy
-        s_min = variable_bounds[counter]
+        s_min = variable_bounds[:spec_entropy_min]
         @threaded for element in eachelement(dg, cache)
             s_min[:, :, element] .= typemax(eltype(s_min))
             for j in eachnode(dg), i in eachnode(dg)
@@ -602,11 +600,10 @@ end
                 s_min[i, j, element] = min(s_min[i, j, element], s)
             end
         end
-        counter += 1
     end
     # Mathematical entropy
     if limiter.math_entropy
-        s_max = variable_bounds[counter]
+        s_max = variable_bounds[:math_entropy_max]
         @threaded for element in eachelement(dg, cache)
             s_max[:, :, element] .= typemin(eltype(s_max))
             for j in eachnode(dg), i in eachnode(dg)


### PR DESCRIPTION
This PR revises the implementation of `variable_bounds`. Before it was an Vector of Array and the access to the right index was very messy. Now, it is a Dictionary with `variable_min/max` as key.

Runtime comparison: Simulation of `elixir_eulermulti_shock_bubble_shockcapturing_subcell_positivity` with the limiter
```
limiter_idp = SubcellLimiterIDP(equations, basis;
                                positivity_variables_cons=[(i+3 for i in eachcomponent(equations))...],
                                local_minmax_variables_cons=[(i+3 for i in eachcomponent(equations))...],
                                positivity_variables_nonlinear=(),
                                positivity_correction_factor=0.1,
                                spec_entropy=false,
                                bar_states=true)
```

Before:
```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerMulticomponentEquations2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                592                run time:       4.18011428e-01 s
 Δt:             1.83448897e-05                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      1.00000000e-02                time/DOF/rhs!:  1.78087369e-07 s
                                               PID:            2.21787485e-07 s
 #DOF:                     1024                alloc'd memory:        637.609 MiB
 #elements:                  64

 Variable:       rho_v1           rho_v2           rho_e            rho1             rho2          
 L2 error:       5.24772927e+01   3.06931413e+00   4.07465794e+04   1.85056062e-01   2.04572270e-02
 Linf error:     2.04049114e+02   1.14734109e+01   1.59153986e+05   1.21543723e+00   1.67926045e-01
 ∑∂S/∂U ⋅ Uₜ :  -2.09705725e+01
 density     :   1.38705622e+00
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.01  Time steps: 592 (accepted), 592 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

───────────────────────────────────────────────────────────────────────────────────────────
                 Trixi.jl                          Time                    Allocations      
                                          ───────────────────────   ────────────────────────
             Tot / % measured:                 755ms /  52.7%           39.9MiB /   7.7%    

 Section                          ncalls     time    %tot     avg     alloc    %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────────────
 rhs!                              1.78k    320ms   80.5%   180μs   11.5KiB    0.4%    6.65B
   volume integral                 1.78k    297ms   74.7%   167μs   2.20KiB    0.1%    1.27B
     subcell-wise blended DG-FV    1.78k    210ms   52.9%   118μs     0.00B    0.0%    0.00B
     calc_lambdas_bar_states!      1.78k   71.5ms   18.0%  40.3μs     0.00B    0.0%    0.00B
     calc_variable_bounds!         1.78k   14.8ms    3.7%  8.32μs     0.00B    0.0%    0.00B
     ~volume integral~             1.78k    458μs    0.1%   258ns   2.20KiB    0.1%    1.27B
   interface flux                  1.78k   14.5ms    3.6%  8.17μs     0.00B    0.0%    0.00B
   surface integral                1.78k   3.12ms    0.8%  1.76μs     0.00B    0.0%    0.00B
   prolong2interfaces              1.78k   2.42ms    0.6%  1.36μs     0.00B    0.0%    0.00B
   ~rhs!~                          1.78k   1.33ms    0.3%   751ns   9.33KiB    0.3%    5.38B
   Jacobian                        1.78k    865μs    0.2%   487ns     0.00B    0.0%    0.00B
   reset ∂u/∂t                     1.78k    762μs    0.2%   429ns     0.00B    0.0%    0.00B
   prolong2boundaries              1.78k   65.3μs    0.0%  36.8ns     0.00B    0.0%    0.00B
   prolong2mortars                 1.78k   57.3μs    0.0%  32.2ns     0.00B    0.0%    0.00B
   mortar flux                     1.78k   51.8μs    0.0%  29.2ns     0.00B    0.0%    0.00B
   boundary flux                   1.78k   34.9μs    0.0%  19.6ns     0.00B    0.0%    0.00B
   source terms                    1.78k   28.7μs    0.0%  16.2ns     0.00B    0.0%    0.00B
 a posteriori limiter              1.78k   47.8ms   12.0%  26.9μs   2.20KiB    0.1%    1.27B
   blending factors                1.78k   40.9ms   10.3%  23.1μs   1.47KiB    0.0%    0.85B
     positivity                    1.78k   21.6ms    5.4%  12.2μs     0.00B    0.0%    0.00B
     local min/max limiting        1.78k   17.1ms    4.3%  9.65μs     0.00B    0.0%    0.00B
     ~blending factors~            1.78k   2.21ms    0.6%  1.24μs   1.47KiB    0.0%    0.85B
   ~a posteriori limiter~          1.78k   6.83ms    1.7%  3.85μs      752B    0.0%    0.42B
 calculate dt                        593   15.6ms    3.9%  26.2μs      752B    0.0%    1.27B
   calc_lambda!                      593   14.8ms    3.7%  24.9μs     0.00B    0.0%    0.00B
   ~calculate dt~                    593    777μs    0.2%  1.31μs      752B    0.0%    1.27B
 check_bounds                      1.78k   5.71ms    1.4%  3.22μs   55.5KiB    1.8%    32.0B
 analyze solution                      3   4.67ms    1.2%  1.56ms   2.55MiB   83.0%   871KiB
 I/O                                   4   3.70ms    0.9%   925μs    467KiB   14.8%   117KiB
   save solution                       3   2.91ms    0.7%   971μs    421KiB   13.4%   140KiB
   ~I/O~                               4    697μs    0.2%   174μs   22.5KiB    0.7%  5.62KiB
   get element variables               3   86.7μs    0.0%  28.9μs   23.5KiB    0.7%  7.84KiB
   get node variables                  3   2.52μs    0.0%   838ns     0.00B    0.0%    0.00B
   save mesh                           3    427ns    0.0%   142ns     0.00B    0.0%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────────────
```

Now: (with Symbols):
```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerMulticomponentEquations2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                592                run time:       4.40529574e-01 s
 Δt:             1.83448897e-05                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      1.00000000e-02                time/DOF/rhs!:  1.79784642e-07 s
                                               PID:            2.34484747e-07 s
 #DOF:                     1024                alloc'd memory:        776.102 MiB
 #elements:                  64

 Variable:       rho_v1           rho_v2           rho_e            rho1             rho2          
 L2 error:       5.24772927e+01   3.06931413e+00   4.07465794e+04   1.85056062e-01   2.04572270e-02
 Linf error:     2.04049114e+02   1.14734109e+01   1.59153986e+05   1.21543723e+00   1.67926045e-01
 ∑∂S/∂U ⋅ Uₜ :  -2.09705725e+01
 density     :   1.38705622e+00
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.01  Time steps: 592 (accepted), 592 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────
 ───────────────────────────────────────────────────────────────────────────────────────────
                 Trixi.jl                          Time                    Allocations      
                                          ───────────────────────   ────────────────────────
             Tot / % measured:                 758ms /  55.5%           45.7MiB /  19.6%    

 Section                          ncalls     time    %tot     avg     alloc    %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────────────
 rhs!                              1.78k    324ms   77.0%   182μs   1.69MiB   18.9%     999B
   volume integral                 1.78k    300ms   71.3%   169μs   1.68MiB   18.8%     993B
     subcell-wise blended DG-FV    1.78k    210ms   50.0%   118μs     0.00B    0.0%    0.00B
     calc_lambdas_bar_states!      1.78k   71.4ms   17.0%  40.2μs     0.00B    0.0%    0.00B
     calc_variable_bounds!         1.78k   17.8ms    4.2%  10.0μs   1.68MiB   18.8%     992B
     ~volume integral~             1.78k    451μs    0.1%   254ns   2.20KiB    0.0%    1.27B
   interface flux                  1.78k   14.8ms    3.5%  8.32μs     0.00B    0.0%    0.00B
   surface integral                1.78k   3.32ms    0.8%  1.87μs     0.00B    0.0%    0.00B
   prolong2interfaces              1.78k   2.42ms    0.6%  1.37μs     0.00B    0.0%    0.00B
   ~rhs!~                          1.78k   1.32ms    0.3%   745ns   9.33KiB    0.1%    5.38B
   Jacobian                        1.78k    864μs    0.2%   486ns     0.00B    0.0%    0.00B
   reset ∂u/∂t                     1.78k    731μs    0.2%   411ns     0.00B    0.0%    0.00B
   prolong2boundaries              1.78k   69.8μs    0.0%  39.3ns     0.00B    0.0%    0.00B
   prolong2mortars                 1.78k   67.9μs    0.0%  38.2ns     0.00B    0.0%    0.00B
   mortar flux                     1.78k   49.2μs    0.0%  27.7ns     0.00B    0.0%    0.00B
   boundary flux                   1.78k   37.7μs    0.0%  21.2ns     0.00B    0.0%    0.00B
   source terms                    1.78k   28.6μs    0.0%  16.1ns     0.00B    0.0%    0.00B
 a posteriori limiter              1.78k   50.9ms   12.1%  28.7μs   2.52MiB   28.2%  1.45KiB
   blending factors                1.78k   44.0ms   10.5%  24.8μs   2.52MiB   28.1%  1.45KiB
     positivity                    1.78k   22.3ms    5.3%  12.6μs    860KiB    9.4%     496B
     local min/max limiting        1.78k   19.1ms    4.5%  10.8μs   1.68MiB   18.8%     992B
     ~blending factors~            1.78k   2.55ms    0.6%  1.43μs   1.47KiB    0.0%    0.85B
   ~a posteriori limiter~          1.78k   6.91ms    1.6%  3.89μs      752B    0.0%    0.42B
 check_bounds                      1.78k   22.1ms    5.3%  12.5μs   1.73MiB   19.4%  1.00KiB
 calculate dt                        593   15.6ms    3.7%  26.3μs      752B    0.0%    1.27B
   calc_lambda!                      593   14.8ms    3.5%  24.9μs     0.00B    0.0%    0.00B
   ~calculate dt~                    593    789μs    0.2%  1.33μs      752B    0.0%    1.27B
 analyze solution                      3   4.65ms    1.1%  1.55ms   2.55MiB   28.5%   872KiB
 I/O                                   4   3.65ms    0.9%   912μs    467KiB    5.1%   117KiB
   save solution                       3   2.91ms    0.7%   972μs    421KiB    4.6%   140KiB
   ~I/O~                               4    644μs    0.2%   161μs   22.5KiB    0.2%  5.62KiB
   get element variables               3   84.4μs    0.0%  28.1μs   23.5KiB    0.3%  7.84KiB
   get node variables                  3   2.57μs    0.0%   856ns     0.00B    0.0%    0.00B
   save mesh                           3    501ns    0.0%   167ns     0.00B    0.0%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────────────
```

There is a small difference in the runtime of `check_bounds` with increased allocations. These are coming from the lines 
```
key_min = Symbol("$(v)_min")
key_max = Symbol("$(v)_max")
```
This is strange since this does not allocate per se
```
julia> a=1
1
julia> @btime Symbol($("$(a)_m"))
  26.570 ns (0 allocations: 0 bytes)
Symbol("1_m")
```

I also checked the Dictionary version with String (instead of Symbols) as keys since most of the time we use `Symbol()` and not `:`. But the simulation was slower than before:
```
────────────────────────────────────────────────────────────────────────────────────────────────────
 Simulation running 'CompressibleEulerMulticomponentEquations2D' with DGSEM(polydeg=3)
────────────────────────────────────────────────────────────────────────────────────────────────────
 #timesteps:                592                run time:       5.02515027e-01 s
 Δt:             1.83448897e-05                └── GC time:    0.00000000e+00 s (0.000%)
 sim. time:      1.00000000e-02                time/DOF/rhs!:  1.78984415e-07 s
                                               PID:            2.68084534e-07 s
 #DOF:                     1024                alloc'd memory:       1036.544 MiB
 #elements:                  64

 Variable:       rho_v1           rho_v2           rho_e            rho1             rho2          
 L2 error:       5.24772927e+01   3.06931413e+00   4.07465794e+04   1.85056062e-01   2.04572270e-02
 Linf error:     2.04049114e+02   1.14734109e+01   1.59153986e+05   1.21543723e+00   1.67926045e-01
 ∑∂S/∂U ⋅ Uₜ :  -2.09705725e+01
 density     :   1.38705622e+00
────────────────────────────────────────────────────────────────────────────────────────────────────

────────────────────────────────────────────────────────────────────────────────────────────────────
Trixi.jl simulation finished.  Final time: 0.01  Time steps: 592 (accepted), 592 (total)
────────────────────────────────────────────────────────────────────────────────────────────────────

 ───────────────────────────────────────────────────────────────────────────────────────────
                 Trixi.jl                          Time                    Allocations      
                                          ───────────────────────   ────────────────────────
             Tot / % measured:                 817ms /  59.0%           45.7MiB /  19.6%    

 Section                          ncalls     time    %tot     avg     alloc    %tot      avg
 ───────────────────────────────────────────────────────────────────────────────────────────
 rhs!                              1.78k    322ms   66.8%   181μs   1.69MiB   18.9%     999B
   volume integral                 1.78k    299ms   62.0%   168μs   1.68MiB   18.8%     993B
     subcell-wise blended DG-FV    1.78k    211ms   43.8%   119μs     0.00B    0.0%    0.00B
     calc_lambdas_bar_states!      1.78k   71.5ms   14.8%  40.2μs     0.00B    0.0%    0.00B
     calc_variable_bounds!         1.78k   15.8ms    3.3%  8.90μs   1.68MiB   18.8%     992B
     ~volume integral~             1.78k    440μs    0.1%   248ns   2.20KiB    0.0%    1.27B
   interface flux                  1.78k   14.5ms    3.0%  8.18μs     0.00B    0.0%    0.00B
   surface integral                1.78k   3.10ms    0.6%  1.74μs     0.00B    0.0%    0.00B
   prolong2interfaces              1.78k   2.45ms    0.5%  1.38μs     0.00B    0.0%    0.00B
   ~rhs!~                          1.78k   1.36ms    0.3%   767ns   9.33KiB    0.1%    5.38B
   Jacobian                        1.78k    875μs    0.2%   493ns     0.00B    0.0%    0.00B
   reset ∂u/∂t                     1.78k    647μs    0.1%   364ns     0.00B    0.0%    0.00B
   prolong2boundaries              1.78k   73.5μs    0.0%  41.4ns     0.00B    0.0%    0.00B
   prolong2mortars                 1.78k   70.5μs    0.0%  39.7ns     0.00B    0.0%    0.00B
   mortar flux                     1.78k   50.7μs    0.0%  28.5ns     0.00B    0.0%    0.00B
   boundary flux                   1.78k   34.8μs    0.0%  19.6ns     0.00B    0.0%    0.00B
   source terms                    1.78k   29.0μs    0.0%  16.3ns     0.00B    0.0%    0.00B
 check_bounds                      1.78k   88.4ms   18.3%  49.8μs   1.73MiB   19.4%  1.00KiB
 a posteriori limiter              1.78k   47.8ms    9.9%  26.9μs   2.52MiB   28.2%  1.45KiB
   blending factors                1.78k   41.1ms    8.5%  23.1μs   2.52MiB   28.1%  1.45KiB
     positivity                    1.78k   20.7ms    4.3%  11.6μs    860KiB    9.4%     496B
     local min/max limiting        1.78k   18.2ms    3.8%  10.3μs   1.68MiB   18.8%     992B
     ~blending factors~            1.78k   2.14ms    0.4%  1.21μs   1.47KiB    0.0%    0.85B
   ~a posteriori limiter~          1.78k   6.80ms    1.4%  3.83μs      752B    0.0%    0.42B
 calculate dt                        593   15.6ms    3.2%  26.3μs      752B    0.0%    1.27B
   calc_lambda!                      593   14.8ms    3.1%  25.0μs     0.00B    0.0%    0.00B
   ~calculate dt~                    593    790μs    0.2%  1.33μs      752B    0.0%    1.27B
 analyze solution                      3   4.69ms    1.0%  1.56ms   2.55MiB   28.5%   872KiB
 I/O                                   4   3.53ms    0.7%   883μs    467KiB    5.1%   117KiB
   save solution                       3   2.84ms    0.6%   946μs    421KiB    4.6%   140KiB
   ~I/O~                               4    607μs    0.1%   152μs   22.5KiB    0.2%  5.62KiB
   get element variables               3   82.2μs    0.0%  27.4μs   23.5KiB    0.3%  7.84KiB
   get node variables                  3   2.56μs    0.0%   854ns     0.00B    0.0%    0.00B
   save mesh                           3    313ns    0.0%   104ns     0.00B    0.0%    0.00B
 ───────────────────────────────────────────────────────────────────────────────────────────
```